### PR TITLE
Update auth.js

### DIFF
--- a/src/static/actions/auth.js
+++ b/src/static/actions/auth.js
@@ -77,7 +77,7 @@ export function authLoginUser(email, password, redirect = '/') {
                     dispatch(authLoginUserFailure({
                         response: {
                             status: 403,
-                            statusText: 'Invalid token'
+                            statusText: e
                         }
                     }));
                 }


### PR DESCRIPTION
The `statusText` should not be hardcoded here. It can be misleading if an error occurs in the `try{}` that is not related to `jwtDecode()`. For example, if a bad path is passed in for redirect. 

It is more helpful to the developer if the actual exception is printed out. In the event `jwtDecode()` fails, it will print "Error: Invalid token specified".