### PR TITLE
Change sourcemap setting in dev webpack config

### DIFF
--- a/webpack/dev.config.js
+++ b/webpack/dev.config.js
@@ -2,7 +2,7 @@ const webpack = require('webpack');
 const ExtractTextPlugin = require('extract-text-webpack-plugin');
 
 module.exports = {
-    devtool: 'source-map', // 'cheap-module-eval-source-map',
+    devtool: 'eval', // 'cheap-module-eval-source-map',
 
     entry: {
         vendor: [


### PR DESCRIPTION
I've been working on a modest project using the boilerplate and my rebuild times average around 4-5 seconds. Changing the source map setting to "eval" brought it down to 1-2 seconds. This has been a huge boost to my productivity.