### PR TITLE
pyopenssl has deprecated the OpenSSL.rand module

### DIFF
--- a/py-requirements/base.txt
+++ b/py-requirements/base.txt
@@ -21,4 +21,4 @@ python-dateutil==2.6.1
 # Logging
 git+https://github.com/Seedstars/django-rest-logger.git
 
-django-rest-knox==3.0.0
+django-rest-knox==3.0.3


### PR DESCRIPTION
If you install the python dependencies and run the django app, you'll get the following error: 

`ModuleNotFoundError: No module named 'OpenSSL.rand'`

This is because pyopenssl has deprecated the OpenSSL.rand module (details [here](https://github.com/pyca/pyopenssl/blob/1eac0e8f9b3829c5401151fabb3f78453ad772a4/CHANGELOG.rst#backward-incompatible-changes-1)).

The folks at django-rest-knox have published a new version that accounts for the change.