### PR TITLE
Update Webpack HtmlWebpackPlugin to manual sort mode.

### DIFF
--- a/webpack/common.config.js
+++ b/webpack/common.config.js
@@ -55,6 +55,8 @@ const common = {
         new HtmlWebpackPlugin({
             template: path.join(__dirname, '../src/static/index.html'),
             hash: true,
+            chunks: ['vendor', 'app'],
+            chunksSortMode: 'manual',
             filename: 'index.html',
             inject: 'body'
         }),


### PR DESCRIPTION
Resolves issue #70.  Updated HtmlWebpackPlugin to import the chunks in the desired order. Vendor -> App