### PR TITLE
Updates Django REST framework version to current stable release: v3.6.4

### DIFF
--- a/py-requirements/base.txt
+++ b/py-requirements/base.txt
@@ -10,7 +10,7 @@ psycopg2==2.7.3
 whitenoise==3.3.0
 
 # Rest Framework
-djangorestframework==3.6.3
+djangorestframework==3.6.4
 
 # Sentry
 raven==6.1.0

--- a/py-requirements/dev.txt
+++ b/py-requirements/dev.txt
@@ -10,6 +10,6 @@ pytest==3.2.1
 pytest-cov==2.5.1
 pytest-django==3.1.2
 pytest-pythonpath==0.7.1
-pytest-xdist==1.19.1
+pytest-xdist==1.20.0
 
 ptpython==0.41


### PR DESCRIPTION
Verified that the tests are passing with djangorestframework v3.6.4