### PR TITLE
Do not invalidate docker cache on package.json changes

### DIFF
--- a/docker/web/Dockerfile
+++ b/docker/web/Dockerfile
@@ -2,7 +2,6 @@ FROM ubuntu:14.04
 MAINTAINER Filipe Garcia <filipe.garcia@seedstarslabs.com>
 
 COPY ./docker/web/web-entrypoint.sh /
-COPY ./package.json /django/package.json
 
 WORKDIR /django
 
@@ -12,3 +11,5 @@ RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add -
 RUN echo "deb http://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
 
 RUN apt-get update && apt-get install -y nodejs yarn
+
+COPY ./package.json /django/package.json


### PR DESCRIPTION
Do not invalidate docker cache on package.json changes

as of https://docs.docker.com/engine/userguide/eng-image/dockerfile_best-practices/#build-cache , if content changes, it will invalidate the cache of all later commands... So the common changed things, should be at the end of file.