### PR TITLE
Updates node-sass version

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "jquery": "3.2.1",
     "less": "2.7.2",
     "less-loader": "4.0.5",
-    "node-sass": "4.5.3",
+    "node-sass": "4.11.0",
     "postcss-import": "10.0.0",
     "postcss-loader": "2.0.6",
     "prop-types": "15.5.10",


### PR DESCRIPTION
```
frontend_1  |     Module build failed: Error: Missing binding /django/node_modules/node-sass/vendor/linux-x64-48/binding.node
frontend_1  |     Node Sass could not find a binding for your current environment: Linux 64-bit with Node.js 6.x
frontend_1  |
frontend_1  |     Found bindings for the following environments:
frontend_1  |       - OS X 64-bit with Unsupported runtime (59)
frontend_1  |
frontend_1  |     This usually happens because your environment has changed since running `npm install`.
frontend_1  |     Run `npm rebuild node-sass --force` to build the binding for your current environment.
```