### PR TITLE
Fix router redirect to original destination after login

### DIFF
--- a/src/static/containers/Login/index.js
+++ b/src/static/containers/Login/index.js
@@ -129,6 +129,7 @@ const mapStateToProps = (state) => {
     return {
         isAuthenticated: state.auth.isAuthenticated,
         isAuthenticating: state.auth.isAuthenticating,
+        location: state.routing.location,
         statusText: state.auth.statusText
     };
 };


### PR DESCRIPTION
Because location is currently not imported into props, the redirect after login will always default to `/`, instead of grabbing the originally intended path from the `/login?next=` param set in [src/static/utils/requireAuthentication.js](https://github.com/Seedstars/django-react-redux-base/blob/master/src/static/utils/requireAuthentication.js). Adding this line will correct that, allowing for successful redirection after user login.